### PR TITLE
SERV-500: Added hash value to detection results to prevent duplicates

### DIFF
--- a/.env
+++ b/.env
@@ -26,7 +26,7 @@ APP_SECRET=8dbdc8f75839b7749bb31ef49d3e565e
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
 #
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
-DATABASE_URL="mysql://db:db@mariadb:3306/db?serverVersion=mariadb-10.5.13"
+DATABASE_URL="mysql://root:password@mariadb:3306/db?serverVersion=mariadb-10.5.13"
 #DATABASE_URL="postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=13&charset=utf8"
 ###< doctrine/doctrine-bundle ###
 

--- a/.env.test
+++ b/.env.test
@@ -4,3 +4,12 @@ APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999
 PANTHER_APP_ENV=panther
 PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
+
+###> doctrine/doctrine-bundle ###
+# Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
+# IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
+#
+# DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
+DATABASE_URL="mysql://db:db@mariadb_test:3306/db?serverVersion=mariadb-10.5.13"
+#DATABASE_URL="postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=13&charset=utf8"
+###< doctrine/doctrine-bundle ###

--- a/.env.test
+++ b/.env.test
@@ -4,12 +4,3 @@ APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999
 PANTHER_APP_ENV=panther
 PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
-
-###> doctrine/doctrine-bundle ###
-# Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
-# IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
-#
-# DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
-DATABASE_URL="mysql://db:db@mariadb_test:3306/db?serverVersion=mariadb-10.5.13"
-#DATABASE_URL="postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=13&charset=utf8"
-###< doctrine/doctrine-bundle ###

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -183,7 +183,7 @@ jobs:
       - name: PHP Unit
         env:
           PORT: ${{ job.services.mariadb.ports[3306] }}
-        run: DATABASE_URL="mysql://db:db@127.0.0.1:$PORT/db_test?serverVersion=mariadb-10.5.13" composer run tests
+        run: DATABASE_URL="mysql://db:db@127.0.0.1:$PORT/db?serverVersion=mariadb-10.5.13" composer run tests
 
   apispec:
     runs-on: ubuntu-20.04

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,11 @@
     "require-dev": {
         "ergebnis/composer-normalize": "^2.23",
         "friendsofphp/php-cs-fixer": "^3.6",
+        "hautelook/alice-bundle": "^2.10",
+        "justinrainbow/json-schema": "^5.2",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-symfony": "^3.1",
+        "symfony/css-selector": "6.0.*",
         "symfony/debug-bundle": "6.0.*",
         "symfony/maker-bundle": "^1.37",
         "symfony/phpunit-bridge": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -116,6 +116,9 @@
             "bin/console hautelook:fixtures:load --no-interaction"
         ],
         "tests": [
+            "bin/console --env=test doctrine:database:drop --if-exists --force --quiet",
+            "bin/console --env=test doctrine:database:create --no-interaction --if-not-exists --quiet",
+            "bin/console --env=test doctrine:migrations:migrate --no-interaction --quiet",
             "vendor/bin/phpunit --stop-on-failure"
         ],
         "update-api-spec": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "93350f38d3ebb90cc63e4bd5d5c948b0",
+    "content-hash": "028079ed3577028ed3da26bde8208269",
     "packages": [
         {
             "name": "api-platform/core",
@@ -8118,6 +8118,88 @@
             "time": "2019-12-04T15:06:13+00:00"
         },
         {
+            "name": "doctrine/data-fixtures",
+            "version": "1.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/data-fixtures.git",
+                "reference": "51c1890e8c5467c421c7cab4579f059ebf720278"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/51c1890e8c5467c421c7cab4579f059ebf720278",
+                "reference": "51c1890e8c5467c421c7cab4579f059ebf720278",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": "^2.13|^3.0",
+                "doctrine/persistence": "^1.3.3|^2.0",
+                "php": "^7.2 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "<2.13",
+                "doctrine/phpcr-odm": "<1.3.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9.0",
+                "doctrine/dbal": "^2.13 || ^3.0",
+                "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
+                "doctrine/orm": "^2.7.0",
+                "ext-sqlite3": "*",
+                "jangregor/phpstan-prophecy": "^0.8.1",
+                "phpstan/phpstan": "^0.12.99",
+                "phpunit/phpunit": "^8.0",
+                "symfony/cache": "^5.0 || ^6.0",
+                "vimeo/psalm": "^4.10"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "For using MongoDB ODM 1.3 with PHP 7 (deprecated)",
+                "doctrine/mongodb-odm": "For loading MongoDB ODM fixtures",
+                "doctrine/orm": "For loading ORM fixtures",
+                "doctrine/phpcr-odm": "For loading PHPCR ODM fixtures"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\DataFixtures\\": "lib/Doctrine/Common/DataFixtures"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Data Fixtures for all Doctrine Object Managers",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "database"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/data-fixtures/issues",
+                "source": "https://github.com/doctrine/data-fixtures/tree/1.5.2"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdata-fixtures",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-20T17:10:56+00:00"
+        },
+        {
             "name": "ergebnis/composer-normalize",
             "version": "2.23.1",
             "source": {
@@ -8392,6 +8474,73 @@
             "time": "2021-12-13T16:54:56+00:00"
         },
         {
+            "name": "fakerphp/faker",
+            "version": "v1.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "d7f08a622b3346766325488aa32ddc93ccdecc75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/d7f08a622b3346766325488aa32ddc93ccdecc75",
+                "reference": "d7f08a622b3346766325488aa32ddc93ccdecc75",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
+                "ext-intl": "*",
+                "symfony/phpunit-bridge": "^4.4 || ^5.2"
+            },
+            "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "v1.19-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.19.0"
+            },
+            "time": "2022-02-02T17:38:57+00:00"
+        },
+        {
             "name": "felixfbecker/advanced-json-rpc",
             "version": "v3.2.1",
             "source": {
@@ -8582,6 +8731,80 @@
             "time": "2022-02-07T18:02:40+00:00"
         },
         {
+            "name": "hautelook/alice-bundle",
+            "version": "2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/AliceBundle.git",
+                "reference": "016ff236de2b103a88f734cb98761588b7db8b2f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/AliceBundle/zipball/016ff236de2b103a88f734cb98761588b7db8b2f",
+                "reference": "016ff236de2b103a88f734cb98761588b7db8b2f",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/data-fixtures": "^1.5",
+                "doctrine/doctrine-bundle": "^2.5",
+                "doctrine/orm": "^2.10.0",
+                "doctrine/persistence": "^2.2",
+                "php": "^7.4 || ^8.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/finder": "^5.4.2 || ^6.0",
+                "symfony/framework-bundle": "^5.4.2 || ^6.0",
+                "theofidry/alice-data-fixtures": "^1.5"
+            },
+            "require-dev": {
+                "doctrine/shards": "^1.0",
+                "phpspec/prophecy": "^1.7",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/phpunit-bridge": "^6.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                },
+                "bin-dir": "bin",
+                "sort-packages": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Hautelook\\AliceBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Baldur Rensch",
+                    "email": "brensch@gmail.com"
+                },
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com",
+                    "homepage": "https://github.com/theofidry"
+                }
+            ],
+            "description": "Symfony bundle to manage fixtures with Alice and Faker.",
+            "keywords": [
+                "Fixture",
+                "alice",
+                "faker",
+                "orm",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/AliceBundle/issues",
+                "source": "https://github.com/theofidry/AliceBundle/tree/2.10.0"
+            },
+            "time": "2022-01-01T18:24:08+00:00"
+        },
+        {
             "name": "justinrainbow/json-schema",
             "version": "5.2.11",
             "source": {
@@ -8765,6 +8988,100 @@
                 }
             ],
             "time": "2020-11-13T09:40:50+00:00"
+        },
+        {
+            "name": "nelmio/alice",
+            "version": "v3.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nelmio/alice.git",
+                "reference": "e8646698ad50fea75551a14a43c0757814e09cea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nelmio/alice/zipball/e8646698ad50fea75551a14a43c0757814e09cea",
+                "reference": "e8646698ad50fea75551a14a43c0757814e09cea",
+                "shasum": ""
+            },
+            "require": {
+                "fakerphp/faker": "^1.10",
+                "myclabs/deep-copy": "^1.10",
+                "php": "^8.0",
+                "sebastian/comparator": "^3.0 || ^4.0",
+                "symfony/property-access": "^4.4 || ^5.4 || ^6.0",
+                "symfony/yaml": "^4.4 || ^5.4 || ^6.0"
+            },
+            "conflict": {
+                "symfony/framework-bundle": "<4.4 || >=5.0.0,<5.2.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "phpspec/prophecy": "^1.6",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.3",
+                "symfony/config": "^4.4 || ^5.4 || ^6.0",
+                "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",
+                "symfony/finder": "^4.4 || ^5.4 || ^6.0",
+                "symfony/http-kernel": "^4.4 || ^5.4 || ^6.0",
+                "symfony/phpunit-bridge": "^5.4 || ^6.0",
+                "symfony/var-dumper": "^4.4 || ^5.4 || ^6.0"
+            },
+            "suggest": {
+                "theofidry/alice-data-fixtures": "Wrapper for Alice to provide a persistence layer."
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": false
+                },
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/deep_clone.php"
+                ],
+                "psr-4": {
+                    "Nelmio\\Alice\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                },
+                {
+                    "name": "Tim Shelburne",
+                    "email": "shelburt02@gmail.com"
+                },
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Expressive fixtures generator",
+            "keywords": [
+                "Fixture",
+                "data",
+                "faker",
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/nelmio/alice/issues",
+                "source": "https://github.com/nelmio/alice/tree/v3.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-10T08:07:10+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -10607,6 +10924,71 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
+            "name": "symfony/css-selector",
+            "version": "v6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "1955d595c12c111629cc814d3f2a2ff13580508a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/1955d595c12c111629cc814d3f2a2ff13580508a",
+                "reference": "1955d595c12c111629cc814d3f2a2ff13580508a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\CssSelector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Converts CSS selectors to XPath expressions",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/css-selector/tree/v6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-02T09:55:41+00:00"
+        },
+        {
             "name": "symfony/debug-bundle",
             "version": "v6.0.3",
             "source": {
@@ -10994,6 +11376,99 @@
                 }
             ],
             "time": "2022-01-02T09:55:41+00:00"
+        },
+        {
+            "name": "theofidry/alice-data-fixtures",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/AliceDataFixtures.git",
+                "reference": "4a290880e177c9db955bb261dd4383667c46462d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/AliceDataFixtures/zipball/4a290880e177c9db955bb261dd4383667c46462d",
+                "reference": "4a290880e177c9db955bb261dd4383667c46462d",
+                "shasum": ""
+            },
+            "require": {
+                "nelmio/alice": "^3.5",
+                "php": "^7.4 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3",
+                "webmozart/assert": "^1.10"
+            },
+            "conflict": {
+                "doctrine/orm": "<2.6.3",
+                "doctrine/persistence": "<2.0",
+                "illuminate/database": "<8.12",
+                "ocramius/proxy-manager": "<2.1",
+                "symfony/framework-bundle": "<4.4 || >5.0,<5.4",
+                "zendframework/zend-code": "<3.3.1"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "phpspec/prophecy": "^1.14.0",
+                "phpspec/prophecy-phpunit": "^2.0.1",
+                "phpunit/phpunit": "^9.5.10",
+                "symfony/phpunit-bridge": "^5.3.8 || ^6.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "To use Doctrine with the MongoDB flavour",
+                "doctrine/data-fixtures": "To use Doctrine",
+                "doctrine/dbal": "To use Doctrine with the PHPCR flavour",
+                "doctrine/mongodb": "To use Doctrine with the MongoDB flavour",
+                "doctrine/mongodb-odm": "To use Doctrine with the MongoDB flavour",
+                "doctrine/orm": "To use Doctrine ORM",
+                "doctrine/phpcr-odm": "To use Doctrine with the PHPCR flavour",
+                "illuminate/database": "To use Eloquent",
+                "jackalope/jackalope-doctrine-dbal": "To use Doctrine with the PHPCR flavour",
+                "ocramius/proxy-manager": "To avoid database connection on kernel boot"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": false
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\AliceDataFixtures\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com",
+                    "homepage": "https://github.com/theofidry"
+                }
+            ],
+            "description": "Nelmio alice extension to persist the loaded fixtures.",
+            "keywords": [
+                "Fixture",
+                "alice",
+                "data",
+                "faker",
+                "orm",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/AliceDataFixtures/issues",
+                "source": "https://github.com/theofidry/AliceDataFixtures/tree/1.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-21T19:45:45+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -13,4 +13,7 @@ return [
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true],
     EasyCorp\Bundle\EasyAdminBundle\EasyAdminBundle::class => ['all' => true],
+    Nelmio\Alice\Bridge\Symfony\NelmioAliceBundle::class => ['dev' => true, 'test' => true],
+    Fidry\AliceDataFixtures\Bridge\Symfony\FidryAliceDataFixturesBundle::class => ['dev' => true, 'test' => true],
+    Hautelook\AliceBundle\HautelookAliceBundle::class => ['dev' => true, 'test' => true],
 ];

--- a/config/packages/hautelook_alice.yaml
+++ b/config/packages/hautelook_alice.yaml
@@ -1,0 +1,5 @@
+when@dev: &dev
+    hautelook_alice:
+        fixtures_path: fixtures
+
+when@test: *dev

--- a/config/packages/nelmio_alice.yaml
+++ b/config/packages/nelmio_alice.yaml
@@ -1,0 +1,12 @@
+when@dev: &dev
+    nelmio_alice:
+        functions_blacklist:
+            - 'current'
+            - 'shuffle'
+            - 'date'
+            - 'time'
+            - 'file'
+            - 'md5'
+            - 'sha1'
+
+when@test: *dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,19 @@ services:
       - MYSQL_DATABASE=db
       #- ENCRYPT=1 # Uncomment to enable database encryption.
 
+  mariadb_test:
+    image: itkdev/mariadb:latest
+    networks:
+      - app
+    ports:
+      - '3306'
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_USER=db
+      - MYSQL_PASSWORD=db
+      - MYSQL_DATABASE=db
+      #- ENCRYPT=1 # Uncomment to enable database encryption.
+
   phpfpm:
     image: itkdev/php8.1-fpm:latest
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,19 +22,6 @@ services:
       - MYSQL_DATABASE=db
       #- ENCRYPT=1 # Uncomment to enable database encryption.
 
-  mariadb_test:
-    image: itkdev/mariadb:latest
-    networks:
-      - app
-    ports:
-      - '3306'
-    environment:
-      - MYSQL_ROOT_PASSWORD=password
-      - MYSQL_USER=db
-      - MYSQL_PASSWORD=db
-      - MYSQL_DATABASE=db
-      #- ENCRYPT=1 # Uncomment to enable database encryption.
-
   phpfpm:
     image: itkdev/php8.1-fpm:latest
     networks:

--- a/fixtures/server.yaml
+++ b/fixtures/server.yaml
@@ -1,0 +1,14 @@
+App\Entity\Server:
+  server_{1..10}:
+    apiKey: <password(40, 255)>
+    name: <domainName()>
+    hostingProvider: <randomElement(['Azure','DBC','IT Relation'])>
+    internalIp: <localIpv4()>
+    externalIp: <ipv4()>
+    aarhusSsl: <boolean()>
+    letsEncryptSsl: <boolean()>
+    veeam: <boolean()>
+    azureBackup: <boolean()>
+    monitoring: <boolean()>
+    databaseVersion: <randomElement(['5.5','5.7','10.3','10.5','10.6'])>
+    system: <randomElement(['Ubuntu 16.04','Ubuntu 18.04','Ubuntu 20.04'])>

--- a/migrations/Version20220321091734.php
+++ b/migrations/Version20220321091734.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220321091734 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE detection_result ADD hash VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE detection_result set hash = UUID()');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_9D26910FD1B862B8 ON detection_result (hash)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX UNIQ_9D26910FD1B862B8 ON detection_result');
+        $this->addSql('ALTER TABLE detection_result DROP hash');
+    }
+}

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -42,7 +42,6 @@ class DashboardController extends AbstractDashboardController
         yield MenuItem::linkToCrud('Detection Results', 'fas fa-upload', DetectionResult::class);
     }
 
-
     public function configureCrud(): Crud
     {
         return Crud::new()

--- a/src/Controller/Admin/DetectionResultCrudController.php
+++ b/src/Controller/Admin/DetectionResultCrudController.php
@@ -10,8 +10,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\CodeEditorField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
-use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
-use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 
 class DetectionResultCrudController extends AbstractCrudController

--- a/src/DataPersister/DetectionResultDataPersister.php
+++ b/src/DataPersister/DetectionResultDataPersister.php
@@ -25,8 +25,6 @@ final class DetectionResultDataPersister implements ContextAwareDataPersisterInt
 
     /**
      * {@inheritDoc}
-     *
-     * @return object
      */
     public function persist($data, array $context = []): object
     {

--- a/src/Entity/DetectionResult.php
+++ b/src/Entity/DetectionResult.php
@@ -8,9 +8,12 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ORM\Entity(repositoryClass: DetectionResultRepository::class)]
-#[ApiResource(collectionOperations: [
-    'post' => ['messenger' => true, 'output' => false, 'status' => 202],
-], itemOperations: [], denormalizationContext: ['groups' => ['write']]
+#[ApiResource(
+//    collectionOperations: [
+//    'post' => ['messenger' => true, 'output' => false, 'status' => 202],
+//],
+//    itemOperations: [],
+//    denormalizationContext: ['groups' => ['write']]
 )]
 class DetectionResult extends AbstractBaseEntity
 {
@@ -29,6 +32,9 @@ class DetectionResult extends AbstractBaseEntity
     #[ORM\Column(type: 'text')]
     #[Groups(['write'])]
     private string $data = '';
+
+    #[ORM\Column(type: 'string', length: 255, unique: true)]
+    private $hash;
 
     public function getType(): ?string
     {
@@ -85,6 +91,18 @@ class DetectionResult extends AbstractBaseEntity
     public function setData(string $data): self
     {
         $this->data = $data;
+
+        return $this;
+    }
+
+    public function getHash(): ?string
+    {
+        return $this->hash;
+    }
+
+    public function generateHash(): self
+    {
+        $this->hash = sha1($this->type.$this->server->getId().$this->data);
 
         return $this;
     }

--- a/src/Entity/DetectionResult.php
+++ b/src/Entity/DetectionResult.php
@@ -9,11 +9,11 @@ use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ORM\Entity(repositoryClass: DetectionResultRepository::class)]
 #[ApiResource(
-//    collectionOperations: [
-//    'post' => ['messenger' => true, 'output' => false, 'status' => 202],
-//],
-//    itemOperations: [],
-//    denormalizationContext: ['groups' => ['write']]
+    collectionOperations: [
+    'post' => ['messenger' => true, 'output' => false, 'status' => 202],
+],
+    itemOperations: [],
+    denormalizationContext: ['groups' => ['write']]
 )]
 class DetectionResult extends AbstractBaseEntity
 {

--- a/symfony.lock
+++ b/symfony.lock
@@ -52,6 +52,9 @@
     "doctrine/common": {
         "version": "3.2.2"
     },
+    "doctrine/data-fixtures": {
+        "version": "1.5.2"
+    },
     "doctrine/dbal": {
         "version": "3.3.2"
     },
@@ -130,6 +133,9 @@
     "ergebnis/json-schema-validator": {
         "version": "2.0.0"
     },
+    "fakerphp/faker": {
+        "version": "v1.19.0"
+    },
     "felixfbecker/advanced-json-rpc": {
         "version": "v3.2.1"
     },
@@ -154,6 +160,19 @@
     "friendsofphp/proxy-manager-lts": {
         "version": "v1.0.5"
     },
+    "hautelook/alice-bundle": {
+        "version": "2.10",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "2.2",
+            "ref": "c84e4f2b9d7f436d7d52e8369230b393367607ec"
+        },
+        "files": [
+            "config/packages/hautelook_alice.yaml",
+            "fixtures/.gitignore"
+        ]
+    },
     "justinrainbow/json-schema": {
         "version": "5.2.11"
     },
@@ -168,6 +187,18 @@
     },
     "myclabs/deep-copy": {
         "version": "1.10.2"
+    },
+    "nelmio/alice": {
+        "version": "3.10",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "3.3",
+            "ref": "42b52d2065dc3fde27912d502c18ca1926e35ae2"
+        },
+        "files": [
+            "config/packages/nelmio_alice.yaml"
+        ]
     },
     "nelmio/cors-bundle": {
         "version": "2.2",
@@ -335,6 +366,9 @@
         "files": [
             "bin/console"
         ]
+    },
+    "symfony/css-selector": {
+        "version": "v6.0.3"
     },
     "symfony/debug-bundle": {
         "version": "6.0",
@@ -640,6 +674,15 @@
     },
     "symfony/yaml": {
         "version": "v5.4.3"
+    },
+    "theofidry/alice-data-fixtures": {
+        "version": "1.5",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "fe5a50faf580eb58f08ada2abe8afbd2d4941e05"
+        }
     },
     "theseer/tokenizer": {
         "version": "1.2.1"

--- a/tests/Api/DetectionResultTest.php
+++ b/tests/Api/DetectionResultTest.php
@@ -41,13 +41,13 @@ class DetectionResultTest extends ApiTestCase
                 ApiKeyAuthenticator::AUTH_HEADER => ApiKeyAuthenticator::AUTH_HEADER_PREFIX.$apikey,
             ],
             'body' => '{
-                          "type": "string",
-                          "rootDir": "string",
-                          "data": "string"
-                        }',
+                "type": "string",
+                "rootDir": "string",
+                "data": "string"
+            }',
         ]);
 
-        $this->assertResponseStatusCodeSame(201, 'Authenticated requests should be accepted');
+        $this->assertResponseStatusCodeSame(202, 'Authenticated requests should be accepted');
 
         $results = $em->getRepository(DetectionResult::class)->findAll();
 

--- a/tests/Api/DetectionResultTest.php
+++ b/tests/Api/DetectionResultTest.php
@@ -38,7 +38,7 @@ class DetectionResultTest extends ApiTestCase
         $response = $client->request('POST', '/api/detection_results', [
             'headers' => [
                 'content-type' => 'application/json',
-                ApiKeyAuthenticator::AUTH_HEADER => ApiKeyAuthenticator::AUTH_HEADER_PREFIX.$apikey
+                ApiKeyAuthenticator::AUTH_HEADER => ApiKeyAuthenticator::AUTH_HEADER_PREFIX.$apikey,
             ],
             'body' => '{
                           "type": "string",
@@ -66,7 +66,7 @@ class DetectionResultTest extends ApiTestCase
         $response = $client->request('POST', '/api/detection_results', [
             'headers' => [
                 'content-type' => 'application/json',
-                ApiKeyAuthenticator::AUTH_HEADER => ApiKeyAuthenticator::AUTH_HEADER_PREFIX.$apikey
+                ApiKeyAuthenticator::AUTH_HEADER => ApiKeyAuthenticator::AUTH_HEADER_PREFIX.$apikey,
             ],
             'body' => '{
                           "type": "string",
@@ -78,7 +78,7 @@ class DetectionResultTest extends ApiTestCase
         $response = $client->request('POST', '/api/detection_results', [
             'headers' => [
                 'content-type' => 'application/json',
-                ApiKeyAuthenticator::AUTH_HEADER => ApiKeyAuthenticator::AUTH_HEADER_PREFIX.$apikey
+                ApiKeyAuthenticator::AUTH_HEADER => ApiKeyAuthenticator::AUTH_HEADER_PREFIX.$apikey,
             ],
             'body' => '{
                           "type": "string1",
@@ -90,7 +90,7 @@ class DetectionResultTest extends ApiTestCase
         $response = $client->request('POST', '/api/detection_results', [
             'headers' => [
                 'content-type' => 'application/json',
-                ApiKeyAuthenticator::AUTH_HEADER => ApiKeyAuthenticator::AUTH_HEADER_PREFIX.$apikey
+                ApiKeyAuthenticator::AUTH_HEADER => ApiKeyAuthenticator::AUTH_HEADER_PREFIX.$apikey,
             ],
             'body' => '{
                           "type": "string",

--- a/tests/Api/DetectionResultTest.php
+++ b/tests/Api/DetectionResultTest.php
@@ -3,9 +3,15 @@
 namespace App\Tests\Api;
 
 use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\DetectionResult;
+use App\Entity\Server;
+use App\Security\ApiKeyAuthenticator;
+use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 
 class DetectionResultTest extends ApiTestCase
 {
+    use RefreshDatabaseTrait;
+
     public function testAuthenticationDenied(): void
     {
         $response = static::createClient()->request('POST', '/api/detection_results', [
@@ -19,5 +25,82 @@ class DetectionResultTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(401, 'Unauthenticated requests should be denied');
+    }
+
+    public function testAuthenticationOk(): void
+    {
+        $client = static::createClient();
+
+        $em = $this->getContainer()->get('doctrine')->getManager();
+        $servers = $em->getRepository(Server::class)->findAll();
+        $apikey = $servers[0]->getApiKey();
+
+        $response = $client->request('POST', '/api/detection_results', [
+            'headers' => [
+                'content-type' => 'application/json',
+                ApiKeyAuthenticator::AUTH_HEADER => ApiKeyAuthenticator::AUTH_HEADER_PREFIX.$apikey
+            ],
+            'body' => '{
+                          "type": "string",
+                          "rootDir": "string",
+                          "data": "string"
+                        }',
+        ]);
+
+        $this->assertResponseStatusCodeSame(201, 'Authenticated requests should be accepted');
+
+        $results = $em->getRepository(DetectionResult::class)->findAll();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function testNoDuplicatesForSameHash(): void
+    {
+        $client = static::createClient();
+        $client->disableReboot();
+
+        $em = $this->getContainer()->get('doctrine')->getManager();
+        $servers = $em->getRepository(Server::class)->findAll();
+        $apikey = $servers[0]->getApiKey();
+
+        $response = $client->request('POST', '/api/detection_results', [
+            'headers' => [
+                'content-type' => 'application/json',
+                ApiKeyAuthenticator::AUTH_HEADER => ApiKeyAuthenticator::AUTH_HEADER_PREFIX.$apikey
+            ],
+            'body' => '{
+                          "type": "string",
+                          "rootDir": "string",
+                          "data": "string"
+                        }',
+        ]);
+
+        $response = $client->request('POST', '/api/detection_results', [
+            'headers' => [
+                'content-type' => 'application/json',
+                ApiKeyAuthenticator::AUTH_HEADER => ApiKeyAuthenticator::AUTH_HEADER_PREFIX.$apikey
+            ],
+            'body' => '{
+                          "type": "string1",
+                          "rootDir": "string1",
+                          "data": "string1"
+                        }',
+        ]);
+
+        $response = $client->request('POST', '/api/detection_results', [
+            'headers' => [
+                'content-type' => 'application/json',
+                ApiKeyAuthenticator::AUTH_HEADER => ApiKeyAuthenticator::AUTH_HEADER_PREFIX.$apikey
+            ],
+            'body' => '{
+                          "type": "string",
+                          "rootDir": "string",
+                          "data": "string"
+                        }',
+        ]);
+
+        $results = $em->getRepository(DetectionResult::class)->findAll();
+
+        $this->assertCount(2, $results, 'Identical POST\s should not write more rows to the DB');
     }
 }


### PR DESCRIPTION
#### Link to ticket

No specific ticket

#### Description

Added `hash` to `DetectionResult`. When new results are POST'ed the hash is used to check if it is a duplicate.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
