### PR TITLE
SERV-611: Added retry logic to result handler for doctrine lock excetions

### DIFF
--- a/src/Command/ReplayDetectionResultsCommand.php
+++ b/src/Command/ReplayDetectionResultsCommand.php
@@ -105,7 +105,7 @@ class ReplayDetectionResultsCommand extends Command
 
         $id = $input->getOption('id');
         if (false !== $id && null !== $id) {
-            $ulid = self::fromRfc4122($id);
+            $ulid = self::fromString($id);
             $queryBuilder
                 ->where('r.id = :id')
                 ->setParameter('id', $ulid->toBinary());
@@ -135,10 +135,6 @@ class ReplayDetectionResultsCommand extends Command
         /** @var DetectionResult $result */
         foreach ($progressBar->iterate($iterable, $max) as $result) {
             $this->handle($result, $context);
-
-            $this->entityManager->flush();
-            $this->entityManager->clear();
-            \gc_collect_cycles();
 
             ++$count;
         }
@@ -211,13 +207,13 @@ class ReplayDetectionResultsCommand extends Command
     }
 
     /**
-     * Get a Ulid from a Rfc4122 string with/without dashes.
+     * Get a Ulid from a string with/without dashes.
      *
      * @param string $ulid
      *
      * @return Ulid
      */
-    private static function fromRfc4122(string $ulid): Ulid
+    private static function fromString(string $ulid): Ulid
     {
         if (32 === strlen($ulid)) {
             $ulid = substr($ulid, 0, 8)
@@ -228,6 +224,6 @@ class ReplayDetectionResultsCommand extends Command
             ;
         }
 
-        return Ulid::fromRfc4122($ulid);
+        return Ulid::fromString($ulid);
     }
 }

--- a/src/Controller/Admin/DetectionResultCrudController.php
+++ b/src/Controller/Admin/DetectionResultCrudController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Admin;
 
 use App\Admin\Field\RootDirField;
 use App\Admin\Field\ServerTypeField;
+use App\Admin\Field\TextMonospaceField;
 use App\Admin\Field\VersionField;
 use App\Entity\DetectionResult;
 use App\Form\Type\Admin\DetectionFilter;
@@ -41,6 +42,7 @@ class DetectionResultCrudController extends AbstractCrudController
 
     public function configureFields(string $pageName): iterable
     {
+        yield TextMonospaceField::new('id')->hideOnIndex();
         yield VersionField::new('type')->setColumns(4);
         yield RootDirField::new('rootDir')->setColumns(12);
         yield ServerTypeField::new('server.type')->setLabel('Type');

--- a/src/Handler/DetectionResultHandler.php
+++ b/src/Handler/DetectionResultHandler.php
@@ -53,7 +53,7 @@ final class DetectionResultHandler implements MessageHandlerInterface
                 $this->entityManager->getConnection()->rollBack();
                 ++$retries;
 
-                if ($retries === self::MAX_RETRIES) {
+                if (self::MAX_RETRIES === $retries) {
                     throw $retryableException;
                 }
             } catch (\Exception $exception) {

--- a/src/Handler/DetectionResultHandler.php
+++ b/src/Handler/DetectionResultHandler.php
@@ -56,6 +56,8 @@ final class DetectionResultHandler implements MessageHandlerInterface
                 if (self::MAX_RETRIES === $retries) {
                     throw $retryableException;
                 }
+
+                \usleep(100000);
             } catch (\Exception $exception) {
                 $this->entityManager->getConnection()->rollBack();
 


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/SERV-611

#### Description

We see data inconsistency in relations and deletions. Replaying detection result fails with deadlock errors.
```
SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction
```

Added retry logic for `Doctrine\DBAL\Exception\RetryableException` in the detection result handler.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
