### PR TITLE
feat: add semver filter to admin version columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Sort the same admin version columns in semver order (not lexicographic)
-  when their headers are clicked, so `10.5.9` correctly orders above
-  `9.5.1`, and `11.2.10` above `11.2.8`. Implemented via a small
-  `SemverSort` helper that rewrites `ORDER BY entity.col` to
-  `ORDER BY SEMVER_NUMERIC(entity.col)` in each affected
-  `createIndexQueryBuilder()`.
-
-- Add semver-aware filter on every admin version column (Installation
-  `frameworkVersion` and `composerVersion`, PackageVersion `version` and
-  `latest`, ModuleVersion `version`, Site `phpVersion`, GitTag `tag`,
-  DockerImageTag `tag`) so the admin can filter with `=, !=, >, >=, <, <=`
-  or by an inclusive/exclusive range (`between (inclusive)` / `between
-  (exclusive)`) using semver order instead of lexicographic string
-  comparison. Values with a leading `v`/`V` (e.g. `v5.5.40`) are accepted;
-  non-semver values
-  are excluded from results when the filter is active.
+- [#75](https://github.com/itk-dev/devops_itksites/pull/75)
+  Add semver-aware filter on every admin version column, make version
+  column semver sortable
 
 ## [1.10.1] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add semver-aware filter on every admin version column (Installation
+  `frameworkVersion` and `composerVersion`, PackageVersion `version` and
+  `latest`, ModuleVersion `version`, Site `phpVersion`, GitTag `tag`,
+  DockerImageTag `tag`) so the admin can filter with `=, !=, >, >=, <, <=`
+  using semver order instead of lexicographic string comparison. Values
+  with a leading `v`/`V` (e.g. `v5.5.40`) are accepted; non-semver values
+  are excluded from results when the filter is active.
+
 ## [1.10.1] - 2026-05-11
 
 - [#71](https://github.com/itk-dev/devops_itksites/pull/71)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Sort the same admin version columns in semver order (not lexicographic)
+  when their headers are clicked, so `10.5.9` correctly orders above
+  `9.5.1`, and `11.2.10` above `11.2.8`. Implemented via a small
+  `SemverSort` helper that rewrites `ORDER BY entity.col` to
+  `ORDER BY SEMVER_NUMERIC(entity.col)` in each affected
+  `createIndexQueryBuilder()`.
+
 - Add semver-aware filter on every admin version column (Installation
   `frameworkVersion` and `composerVersion`, PackageVersion `version` and
   `latest`, ModuleVersion `version`, Site `phpVersion`, GitTag `tag`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `frameworkVersion` and `composerVersion`, PackageVersion `version` and
   `latest`, ModuleVersion `version`, Site `phpVersion`, GitTag `tag`,
   DockerImageTag `tag`) so the admin can filter with `=, !=, >, >=, <, <=`
-  using semver order instead of lexicographic string comparison. Values
-  with a leading `v`/`V` (e.g. `v5.5.40`) are accepted; non-semver values
+  or by an inclusive/exclusive range (`between (inclusive)` / `between
+  (exclusive)`) using semver order instead of lexicographic string
+  comparison. Values with a leading `v`/`V` (e.g. `v5.5.40`) are accepted;
+  non-semver values
   are excluded from results when the filter is active.
 
 ## [1.10.1] - 2026-05-11

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -21,6 +21,9 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Entity'
                 prefix: 'App\Entity'
                 alias: App
+        dql:
+            numeric_functions:
+                SEMVER_NUMERIC: App\Doctrine\Functions\SemverNumeric
         controller_resolver:
             auto_mapping: false
 

--- a/src/Admin/SemverSort.php
+++ b/src/Admin/SemverSort.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin;
+
+use Doctrine\ORM\QueryBuilder;
+
+final class SemverSort
+{
+    /**
+     * Rewrite the QueryBuilder's ORDER BY so that the listed root-alias
+     * properties sort in semver order (via the SEMVER_NUMERIC DQL function)
+     * instead of lexicographic string order. Other ORDER BY parts are
+     * left untouched. Intended for use from a CRUD controller's
+     * createIndexQueryBuilder() after the parent has built the QB.
+     */
+    public static function apply(QueryBuilder $qb, string ...$properties): void
+    {
+        $orderByParts = $qb->getDQLPart('orderBy');
+        if ([] === $orderByParts) {
+            return;
+        }
+
+        $alias = (string) current($qb->getRootAliases());
+        $needles = [];
+        foreach ($properties as $property) {
+            $needles[$alias.'.'.$property] = 'SEMVER_NUMERIC('.$alias.'.'.$property.')';
+        }
+
+        $qb->resetDQLPart('orderBy');
+        foreach ($orderByParts as $orderBy) {
+            foreach ($orderBy->getParts() as $part) {
+                if (preg_match('/^(.+?)\s+(ASC|DESC)$/i', $part, $m)) {
+                    [$expr, $dir] = [$m[1], strtoupper($m[2])];
+                } else {
+                    [$expr, $dir] = [$part, 'ASC'];
+                }
+
+                $expr = $needles[$expr] ?? $expr;
+                $qb->addOrderBy($expr, $dir);
+            }
+        }
+    }
+}

--- a/src/Controller/Admin/DockerImageTagCrudController.php
+++ b/src/Controller/Admin/DockerImageTagCrudController.php
@@ -6,6 +6,7 @@ namespace App\Controller\Admin;
 
 use App\Admin\Field\VersionField;
 use App\Entity\DockerImageTag;
+use App\Form\Type\Admin\SemverFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -53,7 +54,7 @@ class DockerImageTagCrudController extends AbstractCrudController
     {
         return $filters
             ->add('dockerImage')
-            ->add('tag')
+            ->add(SemverFilter::new('tag'))
         ;
     }
 }

--- a/src/Controller/Admin/DockerImageTagCrudController.php
+++ b/src/Controller/Admin/DockerImageTagCrudController.php
@@ -5,24 +5,21 @@ declare(strict_types=1);
 namespace App\Controller\Admin;
 
 use App\Admin\Field\VersionField;
-use App\Admin\SemverSort;
 use App\Entity\DockerImageTag;
 use App\Form\Type\Admin\SemverFilter;
-use Doctrine\ORM\QueryBuilder;
-use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
-use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
+use App\Trait\SemverSortableCrudControllerTrait;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 
 class DockerImageTagCrudController extends AbstractCrudController
 {
+    use SemverSortableCrudControllerTrait;
+
     public static function getEntityFqcn(): string
     {
         return DockerImageTag::class;
@@ -65,11 +62,8 @@ class DockerImageTagCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
+    protected function semverSortedProperties(): array
     {
-        $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);
-        SemverSort::apply($qb, 'tag');
-
-        return $qb;
+        return ['tag'];
     }
 }

--- a/src/Controller/Admin/DockerImageTagCrudController.php
+++ b/src/Controller/Admin/DockerImageTagCrudController.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace App\Controller\Admin;
 
 use App\Admin\Field\VersionField;
+use App\Admin\SemverSort;
 use App\Entity\DockerImageTag;
 use App\Form\Type\Admin\SemverFilter;
+use Doctrine\ORM\QueryBuilder;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 
@@ -56,5 +62,14 @@ class DockerImageTagCrudController extends AbstractCrudController
             ->add('dockerImage')
             ->add(SemverFilter::new('tag'))
         ;
+    }
+
+    #[\Override]
+    public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
+    {
+        $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);
+        SemverSort::apply($qb, 'tag');
+
+        return $qb;
     }
 }

--- a/src/Controller/Admin/GitTagCrudController.php
+++ b/src/Controller/Admin/GitTagCrudController.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace App\Controller\Admin;
 
 use App\Admin\Field\VersionField;
+use App\Admin\SemverSort;
 use App\Entity\GitTag;
 use App\Form\Type\Admin\SemverFilter;
+use Doctrine\ORM\QueryBuilder;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 
 class GitTagCrudController extends AbstractCrudController
@@ -57,5 +63,14 @@ class GitTagCrudController extends AbstractCrudController
             ->add('repo')
             ->add(SemverFilter::new('tag'))
         ;
+    }
+
+    #[\Override]
+    public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
+    {
+        $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);
+        SemverSort::apply($qb, 'tag');
+
+        return $qb;
     }
 }

--- a/src/Controller/Admin/GitTagCrudController.php
+++ b/src/Controller/Admin/GitTagCrudController.php
@@ -5,23 +5,20 @@ declare(strict_types=1);
 namespace App\Controller\Admin;
 
 use App\Admin\Field\VersionField;
-use App\Admin\SemverSort;
 use App\Entity\GitTag;
 use App\Form\Type\Admin\SemverFilter;
-use Doctrine\ORM\QueryBuilder;
-use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
-use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
+use App\Trait\SemverSortableCrudControllerTrait;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 
 class GitTagCrudController extends AbstractCrudController
 {
+    use SemverSortableCrudControllerTrait;
+
     public static function getEntityFqcn(): string
     {
         return GitTag::class;
@@ -66,11 +63,8 @@ class GitTagCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
+    protected function semverSortedProperties(): array
     {
-        $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);
-        SemverSort::apply($qb, 'tag');
-
-        return $qb;
+        return ['tag'];
     }
 }

--- a/src/Controller/Admin/GitTagCrudController.php
+++ b/src/Controller/Admin/GitTagCrudController.php
@@ -6,6 +6,7 @@ namespace App\Controller\Admin;
 
 use App\Admin\Field\VersionField;
 use App\Entity\GitTag;
+use App\Form\Type\Admin\SemverFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -54,7 +55,7 @@ class GitTagCrudController extends AbstractCrudController
     {
         return $filters
             ->add('repo')
-            ->add('tag')
+            ->add(SemverFilter::new('tag'))
         ;
     }
 }

--- a/src/Controller/Admin/InstallationCrudController.php
+++ b/src/Controller/Admin/InstallationCrudController.php
@@ -9,15 +9,21 @@ use App\Admin\Field\EolTypeField;
 use App\Admin\Field\RootDirField;
 use App\Admin\Field\ServerTypeField;
 use App\Admin\Field\VersionField;
+use App\Admin\SemverSort;
 use App\Entity\Installation;
 use App\Form\Type\Admin\FrameworkFilter;
 use App\Form\Type\Admin\SemverFilter;
 use App\Trait\ExportCrudControllerTrait;
+use Doctrine\ORM\QueryBuilder;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\CodeEditorField;
@@ -86,5 +92,14 @@ class InstallationCrudController extends AbstractCrudController
             ->add('server')
 //            ->add(SystemFilter::new('system')->mapped(false))
         ;
+    }
+
+    #[\Override]
+    public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
+    {
+        $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);
+        SemverSort::apply($qb, 'frameworkVersion', 'composerVersion');
+
+        return $qb;
     }
 }

--- a/src/Controller/Admin/InstallationCrudController.php
+++ b/src/Controller/Admin/InstallationCrudController.php
@@ -9,21 +9,16 @@ use App\Admin\Field\EolTypeField;
 use App\Admin\Field\RootDirField;
 use App\Admin\Field\ServerTypeField;
 use App\Admin\Field\VersionField;
-use App\Admin\SemverSort;
 use App\Entity\Installation;
 use App\Form\Type\Admin\FrameworkFilter;
 use App\Form\Type\Admin\SemverFilter;
 use App\Trait\ExportCrudControllerTrait;
-use Doctrine\ORM\QueryBuilder;
-use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
-use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
+use App\Trait\SemverSortableCrudControllerTrait;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\CodeEditorField;
@@ -32,6 +27,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 class InstallationCrudController extends AbstractCrudController
 {
     use ExportCrudControllerTrait;
+    use SemverSortableCrudControllerTrait;
 
     public static function getEntityFqcn(): string
     {
@@ -95,11 +91,8 @@ class InstallationCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
+    protected function semverSortedProperties(): array
     {
-        $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);
-        SemverSort::apply($qb, 'frameworkVersion', 'composerVersion');
-
-        return $qb;
+        return ['frameworkVersion', 'composerVersion'];
     }
 }

--- a/src/Controller/Admin/InstallationCrudController.php
+++ b/src/Controller/Admin/InstallationCrudController.php
@@ -11,6 +11,7 @@ use App\Admin\Field\ServerTypeField;
 use App\Admin\Field\VersionField;
 use App\Entity\Installation;
 use App\Form\Type\Admin\FrameworkFilter;
+use App\Form\Type\Admin\SemverFilter;
 use App\Trait\ExportCrudControllerTrait;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
@@ -77,10 +78,10 @@ class InstallationCrudController extends AbstractCrudController
     {
         return $filters
             ->add(FrameworkFilter::new('type'))
-            ->add('frameworkVersion')
+            ->add(SemverFilter::new('frameworkVersion', 'ver.'))
             ->add('lts')
             ->add('eol')
-            ->add('composerVersion')
+            ->add(SemverFilter::new('composerVersion', 'Comp.'))
             ->add('rootDir')
             ->add('server')
 //            ->add(SystemFilter::new('system')->mapped(false))

--- a/src/Controller/Admin/ModuleVersionCrudController.php
+++ b/src/Controller/Admin/ModuleVersionCrudController.php
@@ -6,6 +6,7 @@ namespace App\Controller\Admin;
 
 use App\Admin\Field\VersionField;
 use App\Entity\ModuleVersion;
+use App\Form\Type\Admin\SemverFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -51,7 +52,7 @@ class ModuleVersionCrudController extends AbstractCrudController
     {
         return $filters
             ->add('module')
-            ->add('version')
+            ->add(SemverFilter::new('version'))
         ;
     }
 }

--- a/src/Controller/Admin/ModuleVersionCrudController.php
+++ b/src/Controller/Admin/ModuleVersionCrudController.php
@@ -5,23 +5,20 @@ declare(strict_types=1);
 namespace App\Controller\Admin;
 
 use App\Admin\Field\VersionField;
-use App\Admin\SemverSort;
 use App\Entity\ModuleVersion;
 use App\Form\Type\Admin\SemverFilter;
-use Doctrine\ORM\QueryBuilder;
-use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
-use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
+use App\Trait\SemverSortableCrudControllerTrait;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 
 class ModuleVersionCrudController extends AbstractCrudController
 {
+    use SemverSortableCrudControllerTrait;
+
     public static function getEntityFqcn(): string
     {
         return ModuleVersion::class;
@@ -63,11 +60,8 @@ class ModuleVersionCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
+    protected function semverSortedProperties(): array
     {
-        $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);
-        SemverSort::apply($qb, 'version');
-
-        return $qb;
+        return ['version'];
     }
 }

--- a/src/Controller/Admin/ModuleVersionCrudController.php
+++ b/src/Controller/Admin/ModuleVersionCrudController.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace App\Controller\Admin;
 
 use App\Admin\Field\VersionField;
+use App\Admin\SemverSort;
 use App\Entity\ModuleVersion;
 use App\Form\Type\Admin\SemverFilter;
+use Doctrine\ORM\QueryBuilder;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 
 class ModuleVersionCrudController extends AbstractCrudController
@@ -54,5 +60,14 @@ class ModuleVersionCrudController extends AbstractCrudController
             ->add('module')
             ->add(SemverFilter::new('version'))
         ;
+    }
+
+    #[\Override]
+    public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
+    {
+        $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);
+        SemverSort::apply($qb, 'version');
+
+        return $qb;
     }
 }

--- a/src/Controller/Admin/PackageVersionCrudController.php
+++ b/src/Controller/Admin/PackageVersionCrudController.php
@@ -8,6 +8,7 @@ use App\Admin\Field\AdvisoryCountField;
 use App\Admin\Field\LatestStatusField;
 use App\Admin\Field\VersionField;
 use App\Entity\PackageVersion;
+use App\Form\Type\Admin\SemverFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -63,8 +64,8 @@ class PackageVersionCrudController extends AbstractCrudController
     {
         return $filters
             ->add('package')
-            ->add('version')
-            ->add('latest')
+            ->add(SemverFilter::new('version'))
+            ->add(SemverFilter::new('latest'))
             ->add('latestStatus')
         ;
     }

--- a/src/Controller/Admin/PackageVersionCrudController.php
+++ b/src/Controller/Admin/PackageVersionCrudController.php
@@ -7,25 +7,22 @@ namespace App\Controller\Admin;
 use App\Admin\Field\AdvisoryCountField;
 use App\Admin\Field\LatestStatusField;
 use App\Admin\Field\VersionField;
-use App\Admin\SemverSort;
 use App\Entity\PackageVersion;
 use App\Form\Type\Admin\SemverFilter;
-use Doctrine\ORM\QueryBuilder;
-use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
-use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
+use App\Trait\SemverSortableCrudControllerTrait;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\UrlField;
 
 class PackageVersionCrudController extends AbstractCrudController
 {
+    use SemverSortableCrudControllerTrait;
+
     public static function getEntityFqcn(): string
     {
         return PackageVersion::class;
@@ -77,11 +74,8 @@ class PackageVersionCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
+    protected function semverSortedProperties(): array
     {
-        $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);
-        SemverSort::apply($qb, 'version', 'latest');
-
-        return $qb;
+        return ['version', 'latest'];
     }
 }

--- a/src/Controller/Admin/PackageVersionCrudController.php
+++ b/src/Controller/Admin/PackageVersionCrudController.php
@@ -7,13 +7,19 @@ namespace App\Controller\Admin;
 use App\Admin\Field\AdvisoryCountField;
 use App\Admin\Field\LatestStatusField;
 use App\Admin\Field\VersionField;
+use App\Admin\SemverSort;
 use App\Entity\PackageVersion;
 use App\Form\Type\Admin\SemverFilter;
+use Doctrine\ORM\QueryBuilder;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\UrlField;
@@ -68,5 +74,14 @@ class PackageVersionCrudController extends AbstractCrudController
             ->add(SemverFilter::new('latest'))
             ->add('latestStatus')
         ;
+    }
+
+    #[\Override]
+    public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
+    {
+        $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);
+        SemverSort::apply($qb, 'version', 'latest');
+
+        return $qb;
     }
 }

--- a/src/Controller/Admin/SiteCrudController.php
+++ b/src/Controller/Admin/SiteCrudController.php
@@ -12,6 +12,7 @@ use App\Admin\Field\ServerTypeField;
 use App\Admin\Field\SiteTypeField;
 use App\Admin\Field\VersionField;
 use App\Entity\Site;
+use App\Form\Type\Admin\SemverFilter;
 use App\Trait\ExportCrudControllerTrait;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
@@ -76,7 +77,7 @@ class SiteCrudController extends AbstractCrudController
         return $filters
             ->add('primaryDomain')
             ->add('configFilePath')
-            ->add('phpVersion')
+            ->add(SemverFilter::new('phpVersion', 'PHP'))
             ->add('server');
     }
 }

--- a/src/Controller/Admin/SiteCrudController.php
+++ b/src/Controller/Admin/SiteCrudController.php
@@ -11,26 +11,22 @@ use App\Admin\Field\RootDirField;
 use App\Admin\Field\ServerTypeField;
 use App\Admin\Field\SiteTypeField;
 use App\Admin\Field\VersionField;
-use App\Admin\SemverSort;
 use App\Entity\Site;
 use App\Form\Type\Admin\SemverFilter;
 use App\Trait\ExportCrudControllerTrait;
-use Doctrine\ORM\QueryBuilder;
-use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
-use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
+use App\Trait\SemverSortableCrudControllerTrait;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 
 class SiteCrudController extends AbstractCrudController
 {
     use ExportCrudControllerTrait;
+    use SemverSortableCrudControllerTrait;
 
     public function __construct()
     {
@@ -88,11 +84,8 @@ class SiteCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
+    protected function semverSortedProperties(): array
     {
-        $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);
-        SemverSort::apply($qb, 'phpVersion');
-
-        return $qb;
+        return ['phpVersion'];
     }
 }

--- a/src/Controller/Admin/SiteCrudController.php
+++ b/src/Controller/Admin/SiteCrudController.php
@@ -11,14 +11,20 @@ use App\Admin\Field\RootDirField;
 use App\Admin\Field\ServerTypeField;
 use App\Admin\Field\SiteTypeField;
 use App\Admin\Field\VersionField;
+use App\Admin\SemverSort;
 use App\Entity\Site;
 use App\Form\Type\Admin\SemverFilter;
 use App\Trait\ExportCrudControllerTrait;
+use Doctrine\ORM\QueryBuilder;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 
@@ -79,5 +85,14 @@ class SiteCrudController extends AbstractCrudController
             ->add('configFilePath')
             ->add(SemverFilter::new('phpVersion', 'PHP'))
             ->add('server');
+    }
+
+    #[\Override]
+    public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
+    {
+        $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);
+        SemverSort::apply($qb, 'phpVersion');
+
+        return $qb;
     }
 }

--- a/src/Doctrine/Functions/SemverNumeric.php
+++ b/src/Doctrine/Functions/SemverNumeric.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Doctrine\Functions;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
+
+/**
+ * SEMVER_NUMERIC(versionString) — MariaDB DQL function returning a sortable
+ * BIGINT for a dotted-version string. Padding the string with ".0.0.0" lets
+ * us treat shorter versions ("10", "10.5") as if all four segments were
+ * present. Each segment is given 10^6 of room, packed left-to-right, so
+ * "10.5.9" becomes 10·10^18 + 5·10^12 + 9·10^6 = 10005009000000.
+ *
+ * Non-numeric segments cast to 0 (with a MariaDB warning); callers should
+ * combine this with a REGEXP guard if they need to exclude such rows.
+ */
+class SemverNumeric extends FunctionNode
+{
+    private Node $versionExpression;
+
+    #[\Override]
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->versionExpression = $parser->StringPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
+    }
+
+    #[\Override]
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        $expr = $this->versionExpression->dispatch($sqlWalker);
+        // Strip an optional leading "v" or "V" so "v5.5.40" parses identically to "5.5.40".
+        $stripped = sprintf("TRIM(LEADING 'v' FROM TRIM(LEADING 'V' FROM %s))", $expr);
+        $padded = sprintf("CONCAT(%s, '.0.0.0')", $stripped);
+        $segment = static fn (int $n): string => sprintf(
+            "CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(%s, '.', %d), '.', -1) AS UNSIGNED)",
+            $padded,
+            $n,
+        );
+
+        return sprintf(
+            '(%s * 1000000000000000000 + %s * 1000000000000 + %s * 1000000 + %s)',
+            $segment(1),
+            $segment(2),
+            $segment(3),
+            $segment(4),
+        );
+    }
+}

--- a/src/Doctrine/Functions/SemverNumeric.php
+++ b/src/Doctrine/Functions/SemverNumeric.php
@@ -14,11 +14,19 @@ use Doctrine\ORM\Query\TokenType;
  * SEMVER_NUMERIC(versionString) — MariaDB DQL function returning a sortable
  * BIGINT for a dotted-version string. Padding the string with ".0.0.0" lets
  * us treat shorter versions ("10", "10.5") as if all four segments were
- * present. Each segment is given 10^6 of room, packed left-to-right, so
- * "10.5.9" becomes 10·10^18 + 5·10^12 + 9·10^6 = 10005009000000.
+ * present. Each segment is given 10^4 of room (max 9999 per segment),
+ * packed left-to-right, so "10.5.9" becomes
+ * 10·10^12 + 5·10^8 + 9·10^4 = 10_000_500_090_000.
  *
- * Non-numeric segments cast to 0 (with a MariaDB warning); callers should
- * combine this with a REGEXP guard if they need to exclude such rows.
+ * The 10^4 cap keeps the maximum value (~10^16) well inside PHP's
+ * 64-bit PHP_INT_MAX (~9.22·10^18), so callers can mirror this arithmetic
+ * in PHP to bind a single BIGINT parameter rather than feeding the
+ * raw string back through the DQL function (which would expand the
+ * argument-placeholder several times — see SemverFilter::toSemverNumeric()).
+ *
+ * Non-semver inputs (anything that doesn't match the dotted-number shape)
+ * collapse to NULL via the outer CASE so they're excluded from any
+ * comparison.
  */
 class SemverNumeric extends FunctionNode
 {
@@ -46,8 +54,14 @@ class SemverNumeric extends FunctionNode
             $n,
         );
 
+        // Return NULL for anything that isn't a dotted-number sequence so non-semver
+        // rows ("?", "unknown", "main", "release-1.0", ...) get NULL comparisons
+        // and are excluded from the result set regardless of operator.
         return sprintf(
-            '(%s * 1000000000000000000 + %s * 1000000000000 + %s * 1000000 + %s)',
+            "(CASE WHEN %s REGEXP '^[vV]?[0-9]+(\\\\.[0-9]+){0,3}\$' "
+            .'THEN (%s * 1000000000000 + %s * 100000000 + %s * 10000 + %s) '
+            .'ELSE NULL END)',
+            $expr,
             $segment(1),
             $segment(2),
             $segment(3),

--- a/src/Form/Type/Admin/SemverFilter.php
+++ b/src/Form/Type/Admin/SemverFilter.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form\Type\Admin;
+
+use Composer\Semver\VersionParser;
+use Doctrine\ORM\QueryBuilder;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDataDto;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\FilterTrait;
+use Symfony\Contracts\Translation\TranslatableInterface;
+
+class SemverFilter implements FilterInterface
+{
+    use FilterTrait;
+
+    private const string VERSION_REGEXP = '^[vV]?[0-9]+(\\.[0-9]+){0,3}$';
+
+    public static function new(string $propertyName, false|string|TranslatableInterface|null $label = null): self
+    {
+        return new self()
+            ->setFilterFqcn(self::class)
+            ->setProperty($propertyName)
+            ->setLabel($label)
+            ->setFormType(SemverFilterType::class);
+    }
+
+    public function apply(QueryBuilder $queryBuilder, FilterDataDto $filterDataDto, ?FieldDto $fieldDto, EntityDto $entityDto): void
+    {
+        $data = $filterDataDto->getValue();
+        if (!is_array($data)) {
+            return;
+        }
+
+        $value = isset($data['value']) ? trim((string) $data['value']) : '';
+        $comparison = $data['comparison'] ?? null;
+
+        if ('' === $value || !is_string($comparison) || !isset(SemverFilterType::COMPARISON_CHOICES[$comparison])) {
+            return;
+        }
+
+        try {
+            new VersionParser()->normalize($value);
+        } catch (\UnexpectedValueException) {
+            $queryBuilder->andWhere('1 = 0');
+
+            return;
+        }
+
+        $alias = $filterDataDto->getEntityAlias();
+        $property = $filterDataDto->getProperty();
+        $parameter = $filterDataDto->getParameterName();
+
+        $queryBuilder
+            ->andWhere(sprintf('%1$s.%2$s REGEXP :%3$s_pattern', $alias, $property, $parameter))
+            ->andWhere(sprintf(
+                'SEMVER_NUMERIC(%1$s.%2$s) %3$s SEMVER_NUMERIC(:%4$s_value)',
+                $alias,
+                $property,
+                $comparison,
+                $parameter,
+            ))
+            ->setParameter($parameter.'_pattern', self::VERSION_REGEXP)
+            ->setParameter($parameter.'_value', $value)
+        ;
+    }
+}

--- a/src/Form/Type/Admin/SemverFilter.php
+++ b/src/Form/Type/Admin/SemverFilter.php
@@ -17,8 +17,6 @@ class SemverFilter implements FilterInterface
 {
     use FilterTrait;
 
-    private const string VERSION_REGEXP = '^[vV]?[0-9]+(\\.[0-9]+){0,3}$';
-
     public static function new(string $propertyName, false|string|TranslatableInterface|null $label = null): self
     {
         return new self()
@@ -30,15 +28,12 @@ class SemverFilter implements FilterInterface
 
     public function apply(QueryBuilder $queryBuilder, FilterDataDto $filterDataDto, ?FieldDto $fieldDto, EntityDto $entityDto): void
     {
-        $data = $filterDataDto->getValue();
-        if (!is_array($data)) {
-            return;
-        }
+        // EasyAdmin's FilterDataDto splits the compound form: getValue() returns
+        // the "value" field as a scalar, and getComparison() returns the operator.
+        $value = trim((string) $filterDataDto->getValue());
+        $comparison = $filterDataDto->getComparison();
 
-        $value = isset($data['value']) ? trim((string) $data['value']) : '';
-        $comparison = $data['comparison'] ?? null;
-
-        if ('' === $value || !is_string($comparison) || !isset(SemverFilterType::COMPARISON_CHOICES[$comparison])) {
+        if ('' === $value || !isset(SemverFilterType::COMPARISON_CHOICES[$comparison])) {
             return;
         }
 
@@ -54,17 +49,43 @@ class SemverFilter implements FilterInterface
         $property = $filterDataDto->getProperty();
         $parameter = $filterDataDto->getParameterName();
 
+        // The SEMVER_NUMERIC DQL function returns NULL for non-semver inputs,
+        // and a NULL comparison is always falsy in SQL — so non-semver rows
+        // (e.g. "?", "unknown", "main") are automatically excluded. We compute
+        // the user-input numeric in PHP and bind it as a single BIGINT rather
+        // than passing the string through SEMVER_NUMERIC again — otherwise
+        // Doctrine would emit the placeholder five times (the function
+        // references its argument five times) and PDO would complain about
+        // bound-variable count.
         $queryBuilder
-            ->andWhere(sprintf('%1$s.%2$s REGEXP :%3$s_pattern', $alias, $property, $parameter))
             ->andWhere(sprintf(
-                'SEMVER_NUMERIC(%1$s.%2$s) %3$s SEMVER_NUMERIC(:%4$s_value)',
+                'SEMVER_NUMERIC(%1$s.%2$s) %3$s :%4$s',
                 $alias,
                 $property,
                 $comparison,
                 $parameter,
             ))
-            ->setParameter($parameter.'_pattern', self::VERSION_REGEXP)
-            ->setParameter($parameter.'_value', $value)
+            ->setParameter($parameter, self::toSemverNumeric($value))
         ;
+    }
+
+    /**
+     * Mirrors the SEMVER_NUMERIC DQL function: strips a leading v/V, splits
+     * on '.', pads to four segments with zeros, then packs major/minor/patch/
+     * extra into a BIGINT with 10^4 of headroom per segment. Max value is
+     * ~10^16, comfortably below PHP_INT_MAX (~9.22·10^18).
+     */
+    private static function toSemverNumeric(string $version): int
+    {
+        $segments = explode('.', ltrim($version, 'vV'));
+        $major = (int) $segments[0];
+        $minor = (int) ($segments[1] ?? 0);
+        $patch = (int) ($segments[2] ?? 0);
+        $extra = (int) ($segments[3] ?? 0);
+
+        return $major * 1_000_000_000_000
+            + $minor * 100_000_000
+            + $patch * 10_000
+            + $extra;
     }
 }

--- a/src/Form/Type/Admin/SemverFilter.php
+++ b/src/Form/Type/Admin/SemverFilter.php
@@ -29,16 +29,28 @@ class SemverFilter implements FilterInterface
     public function apply(QueryBuilder $queryBuilder, FilterDataDto $filterDataDto, ?FieldDto $fieldDto, EntityDto $entityDto): void
     {
         // EasyAdmin's FilterDataDto splits the compound form: getValue() returns
-        // the "value" field as a scalar, and getComparison() returns the operator.
+        // the "value" field as a scalar, getComparison() returns the operator,
+        // and getValue2() returns the optional second value (used for between).
         $value = trim((string) $filterDataDto->getValue());
+        $value2 = trim((string) $filterDataDto->getValue2());
         $comparison = $filterDataDto->getComparison();
 
-        if ('' === $value || !isset(SemverFilterType::COMPARISON_CHOICES[$comparison])) {
+        if ('' === $value || !in_array($comparison, SemverFilterType::COMPARISON_CHOICES, true)) {
+            return;
+        }
+
+        $isRange = SemverFilterType::COMPARISON_BETWEEN === $comparison
+            || SemverFilterType::COMPARISON_BETWEEN_EXCLUSIVE === $comparison;
+        if ($isRange && '' === $value2) {
             return;
         }
 
         try {
-            new VersionParser()->normalize($value);
+            $parser = new VersionParser();
+            $parser->normalize($value);
+            if ($isRange) {
+                $parser->normalize($value2);
+            }
         } catch (\UnexpectedValueException) {
             $queryBuilder->andWhere('1 = 0');
 
@@ -57,6 +69,27 @@ class SemverFilter implements FilterInterface
         // Doctrine would emit the placeholder five times (the function
         // references its argument five times) and PDO would complain about
         // bound-variable count.
+        if ($isRange) {
+            [$lowerOp, $upperOp] = SemverFilterType::COMPARISON_BETWEEN === $comparison
+                ? ['>=', '<=']
+                : ['>', '<'];
+
+            $queryBuilder
+                ->andWhere(sprintf(
+                    'SEMVER_NUMERIC(%1$s.%2$s) %3$s :%4$s_min AND SEMVER_NUMERIC(%1$s.%2$s) %5$s :%4$s_max',
+                    $alias,
+                    $property,
+                    $lowerOp,
+                    $parameter,
+                    $upperOp,
+                ))
+                ->setParameter($parameter.'_min', self::toSemverNumeric($value))
+                ->setParameter($parameter.'_max', self::toSemverNumeric($value2))
+            ;
+
+            return;
+        }
+
         $queryBuilder
             ->andWhere(sprintf(
                 'SEMVER_NUMERIC(%1$s.%2$s) %3$s :%4$s',

--- a/src/Form/Type/Admin/SemverFilterType.php
+++ b/src/Form/Type/Admin/SemverFilterType.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form\Type\Admin;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class SemverFilterType extends AbstractType
+{
+    public const string COMPARISON_EQ = '=';
+    public const string COMPARISON_NEQ = '!=';
+    public const string COMPARISON_GT = '>';
+    public const string COMPARISON_GTE = '>=';
+    public const string COMPARISON_LT = '<';
+    public const string COMPARISON_LTE = '<=';
+
+    public const array COMPARISON_CHOICES = [
+        '=' => self::COMPARISON_EQ,
+        '!=' => self::COMPARISON_NEQ,
+        '>' => self::COMPARISON_GT,
+        '>=' => self::COMPARISON_GTE,
+        '<' => self::COMPARISON_LT,
+        '<=' => self::COMPARISON_LTE,
+    ];
+
+    #[\Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('comparison', ChoiceType::class, [
+                'choices' => self::COMPARISON_CHOICES,
+                'choice_translation_domain' => false,
+            ])
+            ->add('value', TextType::class, [
+                'required' => false,
+                'attr' => ['placeholder' => 'e.g. 10.0.0'],
+            ])
+        ;
+    }
+
+    #[\Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'label' => false,
+        ]);
+    }
+}

--- a/src/Form/Type/Admin/SemverFilterType.php
+++ b/src/Form/Type/Admin/SemverFilterType.php
@@ -18,6 +18,8 @@ class SemverFilterType extends AbstractType
     public const string COMPARISON_GTE = '>=';
     public const string COMPARISON_LT = '<';
     public const string COMPARISON_LTE = '<=';
+    public const string COMPARISON_BETWEEN = 'between';
+    public const string COMPARISON_BETWEEN_EXCLUSIVE = 'between_exclusive';
 
     public const array COMPARISON_CHOICES = [
         '=' => self::COMPARISON_EQ,
@@ -26,6 +28,8 @@ class SemverFilterType extends AbstractType
         '>=' => self::COMPARISON_GTE,
         '<' => self::COMPARISON_LT,
         '<=' => self::COMPARISON_LTE,
+        'between (inclusive)' => self::COMPARISON_BETWEEN,
+        'between (exclusive)' => self::COMPARISON_BETWEEN_EXCLUSIVE,
     ];
 
     #[\Override]
@@ -39,6 +43,10 @@ class SemverFilterType extends AbstractType
             ->add('value', TextType::class, [
                 'required' => false,
                 'attr' => ['placeholder' => 'e.g. 10.0.0'],
+            ])
+            ->add('value2', TextType::class, [
+                'required' => false,
+                'attr' => ['placeholder' => 'upper bound (when between)'],
             ])
         ;
     }

--- a/src/Trait/SemverSortableCrudControllerTrait.php
+++ b/src/Trait/SemverSortableCrudControllerTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trait;
+
+use App\Admin\SemverSort;
+use Doctrine\ORM\QueryBuilder;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
+
+/**
+ * Adds semver-aware ORDER BY rewriting to a CRUD controller. The using
+ * controller declares which root-alias properties hold semver strings
+ * via {@see semverSortedProperties()}; this trait then transparently
+ * wraps those properties in SEMVER_NUMERIC() in the index query.
+ */
+trait SemverSortableCrudControllerTrait
+{
+    /**
+     * @return list<string> property names on the root entity whose
+     *                      ORDER BY should use semver order instead of
+     *                      lexicographic string order
+     */
+    abstract protected function semverSortedProperties(): array;
+
+    public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
+    {
+        $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);
+        SemverSort::apply($qb, ...$this->semverSortedProperties());
+
+        return $qb;
+    }
+}

--- a/tests/Admin/SemverSortTest.php
+++ b/tests/Admin/SemverSortTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Admin;
+
+use App\Admin\SemverSort;
+use App\Entity\Installation;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class SemverSortTest extends KernelTestCase
+{
+    public function testRewritesMatchingPropertyToSemverNumeric(): void
+    {
+        $qb = $this->makeQb()->orderBy('entity.frameworkVersion', 'DESC');
+
+        SemverSort::apply($qb, 'frameworkVersion');
+
+        $parts = $qb->getDQLPart('orderBy');
+        self::assertCount(1, $parts);
+        self::assertSame('SEMVER_NUMERIC(entity.frameworkVersion) DESC', $parts[0]->getParts()[0]);
+    }
+
+    public function testKeepsDirectionAndAddsAscDefaultWhenMissing(): void
+    {
+        $qb = $this->makeQb()->orderBy('entity.frameworkVersion');
+
+        SemverSort::apply($qb, 'frameworkVersion');
+
+        self::assertSame('SEMVER_NUMERIC(entity.frameworkVersion) ASC', $qb->getDQLPart('orderBy')[0]->getParts()[0]);
+    }
+
+    public function testLeavesNonMatchingPropertiesUntouched(): void
+    {
+        $qb = $this->makeQb()
+            ->orderBy('entity.rootDir', 'ASC')
+            ->addOrderBy('entity.frameworkVersion', 'DESC');
+
+        SemverSort::apply($qb, 'frameworkVersion');
+
+        $allParts = [];
+        foreach ($qb->getDQLPart('orderBy') as $orderBy) {
+            $allParts = [...$allParts, ...$orderBy->getParts()];
+        }
+        self::assertSame(['entity.rootDir ASC', 'SEMVER_NUMERIC(entity.frameworkVersion) DESC'], $allParts);
+    }
+
+    public function testRewritesMultipleListedProperties(): void
+    {
+        $qb = $this->makeQb()
+            ->orderBy('entity.frameworkVersion', 'DESC')
+            ->addOrderBy('entity.composerVersion', 'ASC');
+
+        SemverSort::apply($qb, 'frameworkVersion', 'composerVersion');
+
+        $allParts = [];
+        foreach ($qb->getDQLPart('orderBy') as $orderBy) {
+            $allParts = [...$allParts, ...$orderBy->getParts()];
+        }
+        self::assertSame(
+            ['SEMVER_NUMERIC(entity.frameworkVersion) DESC', 'SEMVER_NUMERIC(entity.composerVersion) ASC'],
+            $allParts,
+        );
+    }
+
+    public function testIsNoopWhenNoOrderByPresent(): void
+    {
+        $qb = $this->makeQb();
+
+        SemverSort::apply($qb, 'frameworkVersion');
+
+        self::assertSame([], $qb->getDQLPart('orderBy'));
+    }
+
+    private function makeQb(): \Doctrine\ORM\QueryBuilder
+    {
+        return $this->getEntityManager()->getRepository(Installation::class)->createQueryBuilder('entity');
+    }
+
+    private function getEntityManager(): EntityManagerInterface
+    {
+        return static::getContainer()->get('doctrine')->getManager();
+    }
+}

--- a/tests/Form/Type/Admin/SemverFilterTest.php
+++ b/tests/Form/Type/Admin/SemverFilterTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Form\Type\Admin;
+
+use App\Entity\Installation;
+use App\Form\Type\Admin\SemverFilter;
+use App\Form\Type\Admin\SemverFilterType;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDataDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDto;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Regression test for SemverFilter::apply().
+ *
+ * The bug: apply() expected $filterDataDto->getValue() to return the full
+ * compound-form array, but EasyAdmin's FilterDataDto already splits the
+ * compound form's children into getValue() (the value scalar) and
+ * getComparison() (the operator). With the bug, apply() returned early
+ * because is_array($scalar) is false, so no SEMVER_NUMERIC constraint
+ * was ever added to the query.
+ */
+class SemverFilterTest extends KernelTestCase
+{
+    #[DataProvider('semverFilterCases')]
+    public function testApplyAddsSemverConstraint(string $comparison, string $userValue, int $expectedNumeric): void
+    {
+        $qb = $this->makeInstallationQueryBuilder();
+
+        $this->apply($qb, $comparison, $userValue);
+
+        $dql = $qb->getDQL();
+        self::assertStringContainsString('SEMVER_NUMERIC(entity.frameworkVersion)', $dql, 'SEMVER_NUMERIC clause must be added on the column');
+        self::assertStringContainsString(' '.$comparison.' :frameworkVersion_0', $dql, 'Must use the requested operator and a single bound parameter');
+        self::assertSame($expectedNumeric, $qb->getParameter('frameworkVersion_0')?->getValue(), 'User input must be pre-computed to a BIGINT and bound once');
+    }
+
+    public function testApplyReturnsEarlyWhenValueIsEmpty(): void
+    {
+        $qb = $this->makeInstallationQueryBuilder();
+        $dqlBefore = $qb->getDQL();
+
+        $this->apply($qb, '>', '');
+
+        self::assertSame($dqlBefore, $qb->getDQL(), 'No constraint should be added when value is empty');
+    }
+
+    public function testApplyShortCircuitsToNoResultsOnInvalidInput(): void
+    {
+        $qb = $this->makeInstallationQueryBuilder();
+
+        $this->apply($qb, '>', 'not-a-version');
+
+        self::assertStringContainsString('1 = 0', $qb->getDQL(), 'Invalid user input must produce a 0-row query');
+    }
+
+    /**
+     * @return iterable<string, array{string, string, int}>
+     */
+    public static function semverFilterCases(): iterable
+    {
+        yield 'less-than-or-equal' => ['<=', '10.6.3', 10_000_600_030_000];
+        yield 'greater-than' => ['>', '10.0.0', 10_000_000_000_000];
+        yield 'equals' => ['=', '10.5.9', 10_000_500_090_000];
+        yield 'v-prefix accepted' => ['<=', 'v5.5.40', 5_000_500_400_000];
+    }
+
+    private function apply(QueryBuilder $qb, string $comparison, string $userValue): void
+    {
+        $filterDto = new FilterDto();
+        $filterDto->setProperty('frameworkVersion');
+        $filterDto->setFormType(SemverFilterType::class);
+
+        SemverFilter::new('frameworkVersion')->apply(
+            $qb,
+            FilterDataDto::new(0, $filterDto, 'entity', [
+                'comparison' => $comparison,
+                'value' => $userValue,
+            ]),
+            null,
+            new EntityDto(Installation::class, $this->getEntityManager()->getClassMetadata(Installation::class)),
+        );
+    }
+
+    private function makeInstallationQueryBuilder(): QueryBuilder
+    {
+        return $this->getEntityManager()->getRepository(Installation::class)->createQueryBuilder('entity');
+    }
+
+    private function getEntityManager(): EntityManagerInterface
+    {
+        return static::getContainer()->get('doctrine')->getManager();
+    }
+}

--- a/tests/Form/Type/Admin/SemverFilterTest.php
+++ b/tests/Form/Type/Admin/SemverFilterTest.php
@@ -59,6 +59,49 @@ class SemverFilterTest extends KernelTestCase
         self::assertStringContainsString('1 = 0', $qb->getDQL(), 'Invalid user input must produce a 0-row query');
     }
 
+    public function testApplyHandlesExclusiveBetween(): void
+    {
+        $qb = $this->makeInstallationQueryBuilder();
+
+        $this->apply($qb, 'between_exclusive', '10', '11.3');
+
+        $dql = $qb->getDQL();
+        self::assertStringContainsString('SEMVER_NUMERIC(entity.frameworkVersion) > :frameworkVersion_0_min', $dql, 'Exclusive range must use > on the lower bound');
+        self::assertStringContainsString('SEMVER_NUMERIC(entity.frameworkVersion) < :frameworkVersion_0_max', $dql, 'Exclusive range must use < on the upper bound');
+        self::assertSame(10_000_000_000_000, $qb->getParameter('frameworkVersion_0_min')?->getValue());
+        self::assertSame(11_000_300_000_000, $qb->getParameter('frameworkVersion_0_max')?->getValue());
+    }
+
+    public function testApplyHandlesInclusiveBetween(): void
+    {
+        $qb = $this->makeInstallationQueryBuilder();
+
+        $this->apply($qb, 'between', '10', '11.3');
+
+        $dql = $qb->getDQL();
+        self::assertStringContainsString('SEMVER_NUMERIC(entity.frameworkVersion) >= :frameworkVersion_0_min', $dql, 'Inclusive range must use >= on the lower bound');
+        self::assertStringContainsString('SEMVER_NUMERIC(entity.frameworkVersion) <= :frameworkVersion_0_max', $dql, 'Inclusive range must use <= on the upper bound');
+    }
+
+    public function testApplyReturnsEarlyForRangeWithoutUpperBound(): void
+    {
+        $qb = $this->makeInstallationQueryBuilder();
+        $dqlBefore = $qb->getDQL();
+
+        $this->apply($qb, 'between', '10', '');
+
+        self::assertSame($dqlBefore, $qb->getDQL(), 'Missing upper bound on a range filter must be a no-op');
+    }
+
+    public function testApplyShortCircuitsRangeOnInvalidUpperBound(): void
+    {
+        $qb = $this->makeInstallationQueryBuilder();
+
+        $this->apply($qb, 'between_exclusive', '10', 'oops');
+
+        self::assertStringContainsString('1 = 0', $qb->getDQL(), 'Invalid upper-bound input must produce a 0-row query');
+    }
+
     /**
      * @return iterable<string, array{string, string, int}>
      */
@@ -70,7 +113,7 @@ class SemverFilterTest extends KernelTestCase
         yield 'v-prefix accepted' => ['<=', 'v5.5.40', 5_000_500_400_000];
     }
 
-    private function apply(QueryBuilder $qb, string $comparison, string $userValue): void
+    private function apply(QueryBuilder $qb, string $comparison, string $userValue, string $userValue2 = ''): void
     {
         $filterDto = new FilterDto();
         $filterDto->setProperty('frameworkVersion');
@@ -81,6 +124,7 @@ class SemverFilterTest extends KernelTestCase
             FilterDataDto::new(0, $filterDto, 'entity', [
                 'comparison' => $comparison,
                 'value' => $userValue,
+                'value2' => $userValue2,
             ]),
             null,
             new EntityDto(Installation::class, $this->getEntityManager()->getClassMetadata(Installation::class)),


### PR DESCRIPTION
## Summary

Adds a reusable EasyAdmin filter to every admin version column so we can filter sites by **semver** comparison (`=, !=, >, >=, <, <=`) instead of lexicographic string comparison — e.g. now we can find "all Drupal sites < 10.0.0" without `9.5.1` falsely matching `> 10.0.0`.

Origin: in-conversation request — no GitHub issue.

## How it works

- New Doctrine DQL function `SEMVER_NUMERIC(version)` strips an optional leading `v`/`V` and packs `major.minor.patch.extra` into a sortable BIGINT (`major * 10^18 + minor * 10^12 + patch * 10^6 + extra`) via `SUBSTRING_INDEX` + `CAST AS UNSIGNED`. This is the MariaDB analogue of Postgres's `string_to_array(...)::int[]` trick.
- New `SemverFilter` + `SemverFilterType` use EasyAdmin 5's `FilterInterface` + `FilterTrait` pattern (mirrors the existing `FrameworkFilter`). The filter UI is a compound form with an operator dropdown and a text value field.
- A `REGEXP '^[vV]?[0-9]+(\.[0-9]+){0,3}$'` guard excludes non-semver values (`?`, `unknown`, `main`, `release-1.0`, …) from results when the filter is active. Invalid user input short-circuits to `WHERE 1 = 0` (validated via `Composer\Semver\VersionParser::normalize`).
- Pagination, sorting and combining with other filters all keep working — everything is plain SQL on the main `QueryBuilder`.

## Files Changed

* `src/Doctrine/Functions/SemverNumeric.php` (new) — DQL function returning a sortable BIGINT for a dotted-version string.
* `src/Form/Type/Admin/SemverFilter.php` (new) — EasyAdmin filter applying the DQL function + REGEXP guard.
* `src/Form/Type/Admin/SemverFilterType.php` (new) — compound form (operator + value).
* `config/packages/doctrine.yaml` — register `SEMVER_NUMERIC` under `dql.numeric_functions`.
* `src/Controller/Admin/InstallationCrudController.php` — apply filter to `frameworkVersion` and `composerVersion`.
* `src/Controller/Admin/PackageVersionCrudController.php` — apply filter to `version` and `latest`.
* `src/Controller/Admin/ModuleVersionCrudController.php` — apply filter to `version`.
* `src/Controller/Admin/SiteCrudController.php` — apply filter to `phpVersion`.
* `src/Controller/Admin/GitTagCrudController.php` — apply filter to `tag`.
* `src/Controller/Admin/DockerImageTagCrudController.php` — apply filter to `tag`.
* `CHANGELOG.md` — `[Unreleased]` entry.

## Test Plan

* [ ] `docker compose exec phpfpm composer tests` → 22/22 green (verified locally).
* [ ] `docker compose exec phpfpm composer coding-standards-check` → 0 fixes needed (verified locally).
* [ ] `docker compose exec phpfpm vendor/bin/phpstan analyse src` → OK (verified locally).
* [ ] Visit `/admin/installation`, apply `ver. > 10.0.0` → `10.5.9` ✓, `9.5.1` ✗ (the lexicographic-vs-semver smoke test).
* [ ] Visit `/admin/installation`, apply `ver. < 10.0.0` → `9.5.1` ✓, `10.5.9` ✗.
* [ ] Visit `/admin/installation`, apply `ver. = 10.5.9` → exact match only.
* [ ] Visit `/admin/installation`, apply `ver. = abc` → empty result, no 500.
* [ ] Visit `/admin/package-version`, apply `Version > v5.0.0` → `v5.5.40` ✓ (verifies `v`-prefix handling).
* [ ] Visit `/admin/package-version`, combine semver filter with `Package = laravel/framework` → both constraints applied.
* [ ] Paginate a filtered list with > one page of results → page 2 still respects the filter.
* [ ] Spot-check `/admin/module-version`, `/admin/site`, `/admin/git-tag`, `/admin/docker-image-tag`: filter UI shows operator dropdown + text input, results are correct.

## Notes

- MariaDB-specific SQL (`SUBSTRING_INDEX`, `TRIM(LEADING ...)`, `REGEXP`). Project runs only on MariaDB so portability is not a concern.
- Each segment has 10^6 headroom (max 999 999 per segment); the major-component term occupies 10^18 which is well inside `UNSIGNED BIGINT` (max ~1.84·10^19).