### PR TITLE
feat: add server.type filter and sort to Installation, Site, Domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#77](https://github.com/itk-dev/devops_itksites/pull/77)
   Fix SemverFilter: respect value2 with directional operators
-
+- [#76](https://github.com/itk-dev/devops_itksites/pull/76)
+  Add server type filter and sort on Installation, Site, Domain
 - [#75](https://github.com/itk-dev/devops_itksites/pull/75)
   Add semver-aware filter on every admin version column, make version
   column semver sortable

--- a/src/Controller/Admin/DomainCrudController.php
+++ b/src/Controller/Admin/DomainCrudController.php
@@ -8,6 +8,7 @@ use App\Admin\Field\DomainField;
 use App\Admin\Field\ServerTypeField;
 use App\Admin\Field\SiteTypeField;
 use App\Entity\Domain;
+use App\Form\Type\Admin\ServerTypeFilter;
 use App\Trait\ExportCrudControllerTrait;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
@@ -52,7 +53,7 @@ class DomainCrudController extends AbstractCrudController
         yield DomainField::new('address')->setColumns(12);
         yield SiteTypeField::new('site.type')->hideOnIndex();
         yield AssociationField::new('site')->hideOnIndex();
-        yield ServerTypeField::new('server.type')->setLabel('Type');
+        yield ServerTypeField::new('server.type')->setLabel('Type')->setSortable(true);
         yield AssociationField::new('server');
         yield AssociationField::new('detectionResult')->hideOnIndex();
         yield DateTimeField::new('createdAt')->hideOnIndex();
@@ -66,6 +67,7 @@ class DomainCrudController extends AbstractCrudController
             ->add('address')
             ->add('site')
             ->add('server')
+            ->add(ServerTypeFilter::new('server.type', 'Server type'))
         ;
     }
 }

--- a/src/Controller/Admin/InstallationCrudController.php
+++ b/src/Controller/Admin/InstallationCrudController.php
@@ -12,6 +12,7 @@ use App\Admin\Field\VersionField;
 use App\Entity\Installation;
 use App\Form\Type\Admin\FrameworkFilter;
 use App\Form\Type\Admin\SemverFilter;
+use App\Form\Type\Admin\ServerTypeFilter;
 use App\Trait\ExportCrudControllerTrait;
 use App\Trait\SemverSortableCrudControllerTrait;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
@@ -68,7 +69,7 @@ class InstallationCrudController extends AbstractCrudController
         yield CodeEditorField::new('gitChanges')->hideOnIndex();
         yield AssociationField::new('sites')->hideOnIndex();
         yield RootDirField::new('rootDir')->setColumns(12);
-        yield ServerTypeField::new('server.type')->setLabel('Type');
+        yield ServerTypeField::new('server.type')->setLabel('Type')->setSortable(true);
         yield AssociationField::new('server');
         yield AssociationField::new('detectionResult')->hideOnIndex();
         yield DateTimeField::new('createdAt')->hideOnIndex();
@@ -86,6 +87,7 @@ class InstallationCrudController extends AbstractCrudController
             ->add(SemverFilter::new('composerVersion', 'Comp.'))
             ->add('rootDir')
             ->add('server')
+            ->add(ServerTypeFilter::new('server.type', 'Server type'))
 //            ->add(SystemFilter::new('system')->mapped(false))
         ;
     }

--- a/src/Controller/Admin/SiteCrudController.php
+++ b/src/Controller/Admin/SiteCrudController.php
@@ -13,6 +13,7 @@ use App\Admin\Field\SiteTypeField;
 use App\Admin\Field\VersionField;
 use App\Entity\Site;
 use App\Form\Type\Admin\SemverFilter;
+use App\Form\Type\Admin\ServerTypeFilter;
 use App\Trait\ExportCrudControllerTrait;
 use App\Trait\SemverSortableCrudControllerTrait;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
@@ -67,7 +68,7 @@ class SiteCrudController extends AbstractCrudController
         yield RootDirField::new('rootDir')->setColumns(12)->hideOnIndex();
         yield VersionField::new('phpVersion')->setLabel('PHP');
         yield AssociationField::new('installation')->hideOnIndex();
-        yield ServerTypeField::new('server.type')->setLabel('Type');
+        yield ServerTypeField::new('server.type')->setLabel('Type')->setSortable(true);
         yield AssociationField::new('server');
         yield AssociationField::new('detectionResult')->hideOnIndex();
         yield DateTimeField::new('createdAt')->hideOnIndex();
@@ -80,7 +81,8 @@ class SiteCrudController extends AbstractCrudController
             ->add('primaryDomain')
             ->add('configFilePath')
             ->add(SemverFilter::new('phpVersion', 'PHP'))
-            ->add('server');
+            ->add('server')
+            ->add(ServerTypeFilter::new('server.type', 'Server type'));
     }
 
     #[\Override]

--- a/src/Form/Type/Admin/ServerTypeFilter.php
+++ b/src/Form/Type/Admin/ServerTypeFilter.php
@@ -27,7 +27,32 @@ class ServerTypeFilter implements FilterInterface
 
     public function apply(QueryBuilder $queryBuilder, FilterDataDto $filterDataDto, ?FieldDto $fieldDto, EntityDto $entityDto): void
     {
-        $queryBuilder->andWhere(sprintf('%s.%s = :type', $filterDataDto->getEntityAlias(), $filterDataDto->getProperty()))
-            ->setParameter('type', $filterDataDto->getValue());
+        $rootAlias = $filterDataDto->getEntityAlias();
+        $property = $filterDataDto->getProperty();
+        $parameter = $filterDataDto->getParameterName();
+        $value = $filterDataDto->getValue();
+
+        // EasyAdmin doesn't auto-join nested-property filters; if the
+        // property crosses a relation (e.g. "server.type"), join it
+        // ourselves and reference the joined alias. We reuse the plain
+        // relation name as the join alias to match EA's own sort-side
+        // auto-join (see EntityRepository::addOrderClause), so combining
+        // sort + filter on the same association produces a single JOIN.
+        // Background: https://github.com/EasyCorp/EasyAdminBundle/issues/4120.
+        if (str_contains($property, '.')) {
+            [$relation, $leafProperty] = explode('.', $property, 2);
+            if (!in_array($relation, $queryBuilder->getAllAliases(), true)) {
+                $queryBuilder->leftJoin($rootAlias.'.'.$relation, $relation);
+            }
+            $queryBuilder
+                ->andWhere(sprintf('%s.%s = :%s', $relation, $leafProperty, $parameter))
+                ->setParameter($parameter, $value);
+
+            return;
+        }
+
+        $queryBuilder
+            ->andWhere(sprintf('%s.%s = :%s', $rootAlias, $property, $parameter))
+            ->setParameter($parameter, $value);
     }
 }

--- a/tests/Form/Type/Admin/ServerTypeFilterTest.php
+++ b/tests/Form/Type/Admin/ServerTypeFilterTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Form\Type\Admin;
+
+use App\Entity\Installation;
+use App\Form\Type\Admin\ServerTypeFilter;
+use App\Form\Type\Admin\ServerTypeFilterType;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDataDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDto;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ServerTypeFilterTest extends KernelTestCase
+{
+    public function testApplyOnFlatPropertyComparesAgainstRootAlias(): void
+    {
+        $qb = $this->makeInstallationQueryBuilder();
+
+        $this->apply($qb, 'type', 'prod');
+
+        $dql = $qb->getDQL();
+        self::assertStringContainsString('entity.type = :type_0', $dql);
+        self::assertStringNotContainsString('JOIN', $dql, 'A flat property must not trigger any JOIN');
+        self::assertSame('prod', $qb->getParameter('type_0')?->getValue());
+    }
+
+    public function testApplyOnNestedPropertyJoinsTheRelation(): void
+    {
+        $qb = $this->makeInstallationQueryBuilder();
+
+        $this->apply($qb, 'server.type', 'stg');
+
+        $dql = $qb->getDQL();
+        self::assertStringContainsString('LEFT JOIN entity.server server', $dql, 'Nested filter must auto-join the relation');
+        self::assertStringContainsString('server.type = :server_type_0', $dql);
+        self::assertSame('stg', $qb->getParameter('server_type_0')?->getValue());
+    }
+
+    public function testApplyReusesExistingJoinAliasInsteadOfDuplicating(): void
+    {
+        $qb = $this->makeInstallationQueryBuilder()
+            ->leftJoin('entity.server', 'server');
+
+        $this->apply($qb, 'server.type', 'devops');
+
+        $dql = $qb->getDQL();
+        self::assertSame(1, substr_count($dql, 'LEFT JOIN entity.server'), 'No duplicate join when alias already exists');
+        self::assertStringContainsString('server.type = :server_type_0', $dql);
+    }
+
+    private function apply(QueryBuilder $qb, string $property, string $value): void
+    {
+        $filterDto = new FilterDto();
+        $filterDto->setProperty($property);
+        $filterDto->setFormType(ServerTypeFilterType::class);
+
+        ServerTypeFilter::new($property)->apply(
+            $qb,
+            FilterDataDto::new(0, $filterDto, 'entity', [
+                'comparison' => '=',
+                'value' => $value,
+            ]),
+            null,
+            new EntityDto(Installation::class, $this->getEntityManager()->getClassMetadata(Installation::class)),
+        );
+    }
+
+    private function makeInstallationQueryBuilder(): QueryBuilder
+    {
+        return $this->getEntityManager()->getRepository(Installation::class)->createQueryBuilder('entity');
+    }
+
+    private function getEntityManager(): EntityManagerInterface
+    {
+        return static::getContainer()->get('doctrine')->getManager();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **Server type** (Prod / Stg / DevOps / GPU) filter and makes the **Type** column header sortable on `/admin/installation`, `/admin/site`, and `/admin/domain`.

## Files Changed

* \`src/Form/Type/Admin/ServerTypeFilter.php\` — handle dotted property names by joining the relation; reuse the plain relation name as the join alias so combined filter+sort produces a single JOIN
* \`src/Controller/Admin/InstallationCrudController.php\` — add ServerTypeFilter::new('server.type'); make ServerTypeField sortable
* \`src/Controller/Admin/SiteCrudController.php\` — same
* \`src/Controller/Admin/DomainCrudController.php\` — same

## Test Plan

* [ ] \`/admin/installation\` — Filters → "Server type" dropdown shows Prod / Stg / DevOps / GPU; selecting \`Stg\` returns only stg rows.
* [ ] Click the right-side **Type** column header on the same page — rows reorder by server type alphabetically.
* [ ] Combine filter + sort: \`?sort[server.type]=ASC&filters[server:type]=stg\` — only stg rows, single \`LEFT JOIN server\` in the generated SQL (verified via Symfony profiler).
* [ ] Repeat the filter + sort spot-check on \`/admin/site\` and \`/admin/domain\`.
* [ ] \`docker compose exec phpfpm composer tests\` — 37/37 green.
* [ ] \`docker compose exec phpfpm composer coding-standards-check\` clean; PHPStan clean.