### PR TITLE
CI: update codecov/codecov-action to v7

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,7 +38,7 @@ jobs:
                   docker compose exec -e XDEBUG_MODE=coverage phpfpm vendor/bin/phpunit --coverage-clover=coverage/unit.xml
 
             - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@v7
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   files: ./coverage/unit.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add economics service and sync action/command for service agreement synchronization
 - [#81](https://github.com/itk-dev/devops_itksites/pull/81) 5564: Asset Mapper migration
   - Add Symfony Asset Mapper bundle and importmap
+- Update `codecov/codecov-action` to v7
 
 ## [1.11.2] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add economics service and sync action/command for service agreement synchronization
 - [#81](https://github.com/itk-dev/devops_itksites/pull/81) 5564: Asset Mapper migration
   - Add Symfony Asset Mapper bundle and importmap
-- Update `codecov/codecov-action` to v7
+- [#87](https://github.com/itk-dev/devops_itksites/pull/87) Update `codecov/codecov-action` to v7
 
 ## [1.11.2] - 2026-06-02
 


### PR DESCRIPTION
## What

Update the GitHub Actions Codecov upload step from `codecov/codecov-action@v5` to `@v7`.

## Why

Keep the action current. v6 introduced node24 support and v7 is a maintenance release; the inputs we use (`token`, `files`, `fail_ci_if_error`, `flags`) are unchanged, so no config changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)